### PR TITLE
Implement mem0_service memory server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,41 +1,16 @@
-# The transport for the MCP server - either 'sse' or 'stdio' (defaults to SSE if left empty)
-TRANSPORT=
+# Transport mode: 'sse' or 'stdio'
+TRANSPORT=sse
+# Host for SSE
+HOST=0.0.0.0
+# Port for SSE
+PORT=8050
 
-# Host to bind to if using sse as the transport (leave empty if using stdio)
-HOST=
-
-# Port to listen on if using sse as the transport (leave empty if using stdio)
-PORT=
-
-# The provider for your LLM
-# Set this to either openai, openrouter, or ollama
-# This is needed on top of the base URL for Mem0 (long term memory)
-LLM_PROVIDER=
-
-# Base URL for the OpenAI compatible instance (default is https://api.openai.com/v1)
-# OpenAI: https://api.openai.com/v1
-# Ollama (example): http://localhost:11434/v1
-# OpenRouter: https://openrouter.ai/api/v1
-LLM_BASE_URL=
-
-# OpenAI: https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key
-# Open Router: Get your API Key here after registering: https://openrouter.ai/keys
-# Ollama: No need to set this unless you specifically configured an API key
+# Embedding / LLM provider: openai | openrouter | ollama
+LLM_PROVIDER=openai
+LLM_BASE_URL=https://api.openai.com/v1
 LLM_API_KEY=
+LLM_CHOICE=gpt-4o-mini
+EMBEDDING_MODEL_CHOICE=text-embedding-3-small
 
-# The LLM you want to use for processing memories.
-# OpenAI example: gpt-4o-mini
-# OpenRouter example: anthropic/claude-3.7-sonnet
-# Ollama example: qwen2.5:14b-instruct-8k
-LLM_CHOICE=
-
-# The embedding model you want to use to store memories - this needs to be from the same provider as set above.
-# OpenAI example: text-embedding-3-small
-# Ollama example: nomic-embed-text
-EMBEDDING_MODEL_CHOICE=
-
-# Postgres DB URL used for mem0
-# Format: postgresql://[user]:[password]@[host]:[port]/[database_name]
-# Example: postgresql://postgres:mypassword@localhost:5432/mydb
-# For Supabase Postgres connection, you can find this in "Connect" (top middle of Supabase dashboard) -> Transaction pooler
-DATABASE_URL=
+# Database URL for Postgres or 'memory' for in-memory storage
+DATABASE_URL=postgresql://postgres:postgres@db:5432/mem0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,12 @@
-FROM python:3.12-slim
-
-ARG PORT=8050
-
+FROM python:3.12-slim AS builder
 WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --prefix=/install -r requirements.txt
 
-# Install uv
-RUN pip install uv
-
-# Copy the MCP server files
+FROM python:3.12-slim
+ENV PORT=8050
+WORKDIR /app
+COPY --from=builder /install /usr/local
 COPY . .
-
-# Install packages
-RUN python -m venv .venv
-RUN uv pip install -e .
-
-EXPOSE ${PORT}
-
-# Command to run the MCP server
-CMD ["uv", "run", "src/main.py"]
+EXPOSE $PORT
+CMD ["python", "-m", "src.main"]

--- a/README.md
+++ b/README.md
@@ -1,211 +1,38 @@
-<h1 align="center">MCP-Mem0: Long-Term Memory for AI Agents</h1>
+# mem0_service
 
-<p align="center">
-  <img src="public/Mem0AndMCP.png" alt="Mem0 and MCP Integration" width="600">
-</p>
-
-A template implementation of the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server integrated with [Mem0](https://mem0.ai) for providing AI agents with persistent memory capabilities.
-
-Use this as a reference point to build your MCP servers yourself, or give this as an example to an AI coding assistant and tell it to follow this example for structure and code correctness!
-
-## Overview
-
-This project demonstrates how to build an MCP server that enables AI agents to store, retrieve, and search memories using semantic search. It serves as a practical template for creating your own MCP servers, simply using Mem0 and a practical example.
-
-The implementation follows the best practices laid out by Anthropic for building MCP servers, allowing seamless integration with any MCP-compatible client.
+A simple MCP-compatible memory server providing long term storage for AI agents.
+It exposes three tools over the Model Context Protocol and can run over SSE or
+stdio transport.
 
 ## Features
+- Store memories with embeddings in PostgreSQL (pgvector) or in-memory
+- Semantic search using cosine similarity
+- Works with OpenAI, OpenRouter or Ollama for embeddings
+- Health check at `/health`
 
-The server provides three essential memory management tools:
-
-1. **`save_memory`**: Store any information in long-term memory with semantic indexing
-2. **`get_all_memories`**: Retrieve all stored memories for comprehensive context
-3. **`search_memories`**: Find relevant memories using semantic search
-
-## Prerequisites
-
-- Python 3.12+
-- Supabase or any PostgreSQL database (for vector storage of memories)
-- API keys for your chosen LLM provider (OpenAI, OpenRouter, or Ollama)
-- Docker if running the MCP server as a container (recommended)
-
-## Installation
-
-### Using uv
-
-1. Install uv if you don't have it:
+## Quick start
+1. Copy `.env.example` to `.env` and adjust values.
+2. Run with Docker Compose:
    ```bash
-   pip install uv
+   docker compose up
    ```
+   You should see `🚀 Server listening on http://0.0.0.0:8050`.
 
-2. Clone this repository:
-   ```bash
-   git clone https://github.com/coleam00/mcp-mem0.git
-   cd mcp-mem0
-   ```
-
-3. Install dependencies:
-   ```bash
-   uv pip install -e .
-   ```
-
-4. Create a `.env` file based on `.env.example`:
-   ```bash
-   cp .env.example .env
-   ```
-
-5. Configure your environment variables in the `.env` file (see Configuration section)
-
-### Using Docker (Recommended)
-
-1. Build the Docker image:
-   ```bash
-   docker build -t mcp/mem0 --build-arg PORT=8050 .
-   ```
-
-2. Create a `.env` file based on `.env.example` and configure your environment variables
-
-## Configuration
-
-The following environment variables can be configured in your `.env` file:
-
-| Variable | Description | Example |
-|----------|-------------|----------|
-| `TRANSPORT` | Transport protocol (sse or stdio) | `sse` |
-| `HOST` | Host to bind to when using SSE transport | `0.0.0.0` |
-| `PORT` | Port to listen on when using SSE transport | `8050` |
-| `LLM_PROVIDER` | LLM provider (openai, openrouter, or ollama) | `openai` |
-| `LLM_BASE_URL` | Base URL for the LLM API | `https://api.openai.com/v1` |
-| `LLM_API_KEY` | API key for the LLM provider | `sk-...` |
-| `LLM_CHOICE` | LLM model to use | `gpt-4o-mini` |
-| `EMBEDDING_MODEL_CHOICE` | Embedding model to use | `text-embedding-3-small` |
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@host:port/db` |
-
-## Running the Server
-
-### Using uv
-
-#### SSE Transport
-
+### Curl test
+Save a memory then search for it:
 ```bash
-# Set TRANSPORT=sse in .env then:
-uv run src/main.py
+curl -X POST http://localhost:8050/save_memory \
+     -H "Content-Type: application/json" \
+     -d '{"text":"Craig closed $2M in premiums"}'
+
+curl -X POST http://localhost:8050/search_memories \
+     -H "Content-Type: application/json" \
+     -d '{"query":"premiums"}'
 ```
 
-The MCP server will essentially be run as an API endpoint that you can then connect to with config shown below.
-
-#### Stdio Transport
-
-With stdio, the MCP client iself can spin up the MCP server, so nothing to run at this point.
-
-### Using Docker
-
-#### SSE Transport
-
+### Stdio example
+Set `TRANSPORT=stdio` in `.env` and run:
 ```bash
-docker run --env-file .env -p:8050:8050 mcp/mem0
+python -m src.main
 ```
-
-The MCP server will essentially be run as an API endpoint within the container that you can then connect to with config shown below.
-
-#### Stdio Transport
-
-With stdio, the MCP client iself can spin up the MCP server container, so nothing to run at this point.
-
-## Integration with MCP Clients
-
-### SSE Configuration
-
-Once you have the server running with SSE transport, you can connect to it using this configuration:
-
-```json
-{
-  "mcpServers": {
-    "mem0": {
-      "transport": "sse",
-      "url": "http://localhost:8050/sse"
-    }
-  }
-}
-```
-
-> **Note for Windsurf users**: Use `serverUrl` instead of `url` in your configuration:
-> ```json
-> {
->   "mcpServers": {
->     "mem0": {
->       "transport": "sse",
->       "serverUrl": "http://localhost:8050/sse"
->     }
->   }
-> }
-> ```
-
-> **Note for n8n users**: Use host.docker.internal instead of localhost since n8n has to reach outside of it's own container to the host machine:
-> 
-> So the full URL in the MCP node would be: http://host.docker.internal:8050/sse
-
-Make sure to update the port if you are using a value other than the default 8050.
-
-### Python with Stdio Configuration
-
-Add this server to your MCP configuration for Claude Desktop, Windsurf, or any other MCP client:
-
-```json
-{
-  "mcpServers": {
-    "mem0": {
-      "command": "your/path/to/mcp-mem0/.venv/Scripts/python.exe",
-      "args": ["your/path/to/mcp-mem0/src/main.py"],
-      "env": {
-        "TRANSPORT": "stdio",
-        "LLM_PROVIDER": "openai",
-        "LLM_BASE_URL": "https://api.openai.com/v1",
-        "LLM_API_KEY": "YOUR-API-KEY",
-        "LLM_CHOICE": "gpt-4o-mini",
-        "EMBEDDING_MODEL_CHOICE": "text-embedding-3-small",
-        "DATABASE_URL": "YOUR-DATABASE-URL"
-      }
-    }
-  }
-}
-```
-
-### Docker with Stdio Configuration
-
-```json
-{
-  "mcpServers": {
-    "mem0": {
-      "command": "docker",
-      "args": ["run", "--rm", "-i", 
-               "-e", "TRANSPORT", 
-               "-e", "LLM_PROVIDER", 
-               "-e", "LLM_BASE_URL", 
-               "-e", "LLM_API_KEY", 
-               "-e", "LLM_CHOICE", 
-               "-e", "EMBEDDING_MODEL_CHOICE", 
-               "-e", "DATABASE_URL", 
-               "mcp/mem0"],
-      "env": {
-        "TRANSPORT": "stdio",
-        "LLM_PROVIDER": "openai",
-        "LLM_BASE_URL": "https://api.openai.com/v1",
-        "LLM_API_KEY": "YOUR-API-KEY",
-        "LLM_CHOICE": "gpt-4o-mini",
-        "EMBEDDING_MODEL_CHOICE": "text-embedding-3-small",
-        "DATABASE_URL": "YOUR-DATABASE-URL"
-      }
-    }
-  }
-}
-```
-
-## Building Your Own Server
-
-This template provides a foundation for building more complex MCP servers. To build your own:
-
-1. Add your own tools by creating methods with the `@mcp.tool()` decorator
-2. Create your own lifespan function to add your own dependencies (clients, database connections, etc.)
-3. Modify the `utils.py` file for any helper functions you need for your MCP server
-4. Feel free to add prompts and resources as well  with `@mcp.resource()` and `@mcp.prompt()`
+A compatible client can then communicate with the process via stdin/stdout.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  mem0_service:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "${PORT:-8050}:8050"
+    depends_on:
+      - db
+  db:
+    image: ankane/pgvector
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: mem0
+    ports:
+      - "5432:5432"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+sqlalchemy==2.0.30
+pgvector==0.2.5
+asyncpg==0.29.0
+httpx==0.27.0
+mcp_sdk==1.3.0
+python-dotenv==1.0.1
+psycopg2-binary==2.9.9

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,79 @@
+import os
+import uuid
+from datetime import datetime
+from typing import List
+
+DATABASE_URL = os.getenv("DATABASE_URL", "memory")
+
+try:
+    from sqlalchemy import create_engine, Column, DateTime, Text, func
+    from sqlalchemy.orm import declarative_base, sessionmaker
+    from sqlalchemy.dialects.postgresql import UUID
+    from pgvector.sqlalchemy import Vector
+except Exception:  # pragma: no cover - optional deps
+    create_engine = Column = DateTime = Text = func = None
+    declarative_base = lambda: None
+    sessionmaker = lambda *a, **k: None
+    UUID = Vector = None
+
+Base = declarative_base() if declarative_base else None
+
+if Base:
+    class MemoryORM(Base):
+        __tablename__ = "memories"
+        id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+        text = Column(Text, nullable=False)
+        embedding = Column(Vector(1536))
+        ts = Column(DateTime(timezone=True), server_default=func.now())
+
+engine = None
+SessionLocal = None
+_mem_store: List[dict] = []
+
+
+def init_db() -> None:
+    global engine, SessionLocal
+    if DATABASE_URL == "memory" or not create_engine:
+        engine = None
+        SessionLocal = None
+    else:
+        engine = create_engine(DATABASE_URL)
+        SessionLocal = sessionmaker(bind=engine)
+        Base.metadata.create_all(engine)
+
+
+def save_memory(text: str, embedding: List[float]) -> str:
+    text = " ".join(text.split())[:8000]
+    if DATABASE_URL == "memory" or not SessionLocal:
+        mem_id = str(uuid.uuid4())
+        _mem_store.append({"id": mem_id, "text": text, "embedding": embedding, "ts": datetime.utcnow()})
+        return mem_id
+    with SessionLocal() as session:
+        mem = MemoryORM(text=text, embedding=embedding)
+        session.add(mem)
+        session.commit()
+        return str(mem.id)
+
+
+def search_memories(embedding: List[float], limit: int = 5) -> List[str]:
+    if DATABASE_URL == "memory" or not SessionLocal:
+        def dot(a, b):
+            return sum(x*y for x, y in zip(a, b))
+        scored = sorted([(dot(m['embedding'], embedding), m['text']) for m in _mem_store], reverse=True)
+        return [t for _, t in scored[:limit]]
+    with SessionLocal() as session:
+        result = (
+            session.query(MemoryORM.text)
+            .order_by(MemoryORM.embedding.cosine_distance(embedding))
+            .limit(limit)
+            .all()
+        )
+        return [r[0] for r in result]
+
+
+def get_all_memories() -> List[str]:
+    if DATABASE_URL == "memory" or not SessionLocal:
+        return [m['text'] for m in _mem_store]
+    with SessionLocal() as session:
+        result = session.query(MemoryORM.text).order_by(MemoryORM.ts).all()
+        return [r[0] for r in result]

--- a/src/llm.py
+++ b/src/llm.py
@@ -1,0 +1,27 @@
+import os
+import httpx
+from typing import List
+
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", "https://api.openai.com/v1")
+LLM_API_KEY = os.getenv("LLM_API_KEY", "")
+EMBED_MODEL = os.getenv("EMBEDDING_MODEL_CHOICE", "text-embedding-3-small")
+
+async def get_embedding(text: str) -> List[float]:
+    headers = {"Authorization": f"Bearer {LLM_API_KEY}"} if LLM_API_KEY else {}
+    if LLM_PROVIDER in {"openai", "openrouter"}:
+        url = f"{LLM_BASE_URL}/embeddings"
+        payload = {"input": text, "model": EMBED_MODEL}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json=payload, headers=headers, timeout=30)
+            resp.raise_for_status()
+            return resp.json()["data"][0]["embedding"]
+    elif LLM_PROVIDER == "ollama":
+        url = f"{LLM_BASE_URL}/embeddings"
+        payload = {"prompt": text, "model": EMBED_MODEL}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json=payload, headers=headers, timeout=30)
+            resp.raise_for_status()
+            return resp.json()["embedding"]
+    else:
+        raise ValueError(f"Unsupported provider {LLM_PROVIDER}")

--- a/src/main.py
+++ b/src/main.py
@@ -1,128 +1,89 @@
-from mcp.server.fastmcp import FastMCP, Context
-from contextlib import asynccontextmanager
-from collections.abc import AsyncIterator
-from dataclasses import dataclass
-from dotenv import load_dotenv
-from mem0 import Memory
-import asyncio
-import json
 import os
+import asyncio
+import logging
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from mcp_sdk.server import MCPServer, Context
+from dotenv import load_dotenv
 
-from utils import get_mem0_client
+from db import init_db, save_memory, search_memories, get_all_memories
+from llm import get_embedding
 
 load_dotenv()
 
-# Default user ID for memory operations
-DEFAULT_USER_ID = "user"
+HOST = os.getenv("HOST", "0.0.0.0")
+PORT = int(os.getenv("PORT", "8050"))
+TRANSPORT = os.getenv("TRANSPORT", "sse")
 
-# Create a dataclass for our application context
-@dataclass
-class Mem0Context:
-    """Context for the Mem0 MCP server."""
-    mem0_client: Memory
+logging.basicConfig(level=logging.INFO, format='{"timestamp":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s"}')
+logger = logging.getLogger(__name__)
 
-@asynccontextmanager
-async def mem0_lifespan(server: FastMCP) -> AsyncIterator[Mem0Context]:
-    """
-    Manages the Mem0 client lifecycle.
-    
-    Args:
-        server: The FastMCP server instance
-        
-    Yields:
-        Mem0Context: The context containing the Mem0 client
-    """
-    # Create and return the Memory client with the helper function in utils.py
-    mem0_client = get_mem0_client()
-    
-    try:
-        yield Mem0Context(mem0_client=mem0_client)
-    finally:
-        # No explicit cleanup needed for the Mem0 client
-        pass
+app = FastAPI()
 
-# Initialize FastMCP server with the Mem0 client as context
-mcp = FastMCP(
-    "mcp-mem0",
-    description="MCP server for long term memory storage and retrieval with Mem0",
-    lifespan=mem0_lifespan,
-    host=os.getenv("HOST", "0.0.0.0"),
-    port=os.getenv("PORT", "8050")
-)        
+mcp = MCPServer("mem0_service", app=app)
+
+@app.on_event("startup")
+async def startup() -> None:
+    init_db()
+    logger.info("service started")
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok"}
 
 @mcp.tool()
-async def save_memory(ctx: Context, text: str) -> str:
-    """Save information to your long-term memory.
-
-    This tool is designed to store any type of information that might be useful in the future.
-    The content will be processed and indexed for later retrieval through semantic search.
-
-    Args:
-        ctx: The MCP server provided context which includes the Mem0 client
-        text: The content to store in memory, including any relevant details and context
-    """
-    try:
-        mem0_client = ctx.request_context.lifespan_context.mem0_client
-        messages = [{"role": "user", "content": text}]
-        mem0_client.add(messages, user_id=DEFAULT_USER_ID)
-        return f"Successfully saved memory: {text[:100]}..." if len(text) > 100 else f"Successfully saved memory: {text}"
-    except Exception as e:
-        return f"Error saving memory: {str(e)}"
+async def save_memory_tool(ctx: Context, text: str) -> str:
+    emb = await get_embedding(text)
+    mem_id = save_memory(text, emb)
+    return mem_id
 
 @mcp.tool()
-async def get_all_memories(ctx: Context) -> str:
-    """Get all stored memories for the user.
-    
-    Call this tool when you need complete context of all previously memories.
-
-    Args:
-        ctx: The MCP server provided context which includes the Mem0 client
-
-    Returns a JSON formatted list of all stored memories, including when they were created
-    and their content. Results are paginated with a default of 50 items per page.
-    """
-    try:
-        mem0_client = ctx.request_context.lifespan_context.mem0_client
-        memories = mem0_client.get_all(user_id=DEFAULT_USER_ID)
-        if isinstance(memories, dict) and "results" in memories:
-            flattened_memories = [memory["memory"] for memory in memories["results"]]
-        else:
-            flattened_memories = memories
-        return json.dumps(flattened_memories, indent=2)
-    except Exception as e:
-        return f"Error retrieving memories: {str(e)}"
+async def search_memories_tool(ctx: Context, query: str, limit: int = 5) -> str:
+    emb = await get_embedding(query)
+    results = search_memories(emb, limit)
+    return "\n".join(results)
 
 @mcp.tool()
-async def search_memories(ctx: Context, query: str, limit: int = 3) -> str:
-    """Search memories using semantic search.
+async def get_all_memories_tool(ctx: Context) -> str:
+    return "\n".join(get_all_memories())
 
-    This tool should be called to find relevant information from your memory. Results are ranked by relevance.
-    Always search your memories before making decisions to ensure you leverage your existing knowledge.
+@app.post("/save_memory")
+async def api_save(req: Request):
+    data = await req.json()
+    emb = await get_embedding(data.get("text", ""))
+    mem_id = save_memory(data.get("text", ""), emb)
+    return {"id": mem_id}
 
-    Args:
-        ctx: The MCP server provided context which includes the Mem0 client
-        query: Search query string describing what you're looking for. Can be natural language.
-        limit: Maximum number of results to return (default: 3)
-    """
-    try:
-        mem0_client = ctx.request_context.lifespan_context.mem0_client
-        memories = mem0_client.search(query, user_id=DEFAULT_USER_ID, limit=limit)
-        if isinstance(memories, dict) and "results" in memories:
-            flattened_memories = [memory["memory"] for memory in memories["results"]]
-        else:
-            flattened_memories = memories
-        return json.dumps(flattened_memories, indent=2)
-    except Exception as e:
-        return f"Error searching memories: {str(e)}"
+@app.post("/search_memories")
+async def api_search(req: Request):
+    data = await req.json()
+    emb = await get_embedding(data.get("query", ""))
+    results = search_memories(emb, data.get("limit", 5))
+    return {"results": results}
+
+@app.get("/get_all_memories")
+async def api_get_all():
+    return {"results": get_all_memories()}
+
+@app.get("/sse")
+async def sse_endpoint(request: Request):
+    async def event_generator():
+        while True:
+            if await request.is_disconnected():
+                break
+            await asyncio.sleep(1)
+            yield f"data: ping\n\n"
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 async def main():
-    transport = os.getenv("TRANSPORT", "sse")
-    if transport == 'sse':
-        # Run the MCP server with sse transport
-        await mcp.run_sse_async()
-    else:
-        # Run the MCP server with stdio transport
+    if TRANSPORT == "stdio":
         await mcp.run_stdio_async()
+    else:
+        import uvicorn
+        config = uvicorn.Config(app, host=HOST, port=PORT, log_level="info")
+        server = uvicorn.Server(config)
+        logger.info(f"\ud83d\ude80 Server listening on http://{HOST}:{PORT}")
+        await server.serve()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -1,0 +1,16 @@
+import os, sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+import db
+
+os.environ['DATABASE_URL'] = 'memory'
+
+def test_round_trip():
+    db.init_db()
+    text = "hello world"
+    emb = [0.1, 0.2, 0.3]
+    mem_id = db.save_memory(text, emb)
+    assert mem_id
+    all_mem = db.get_all_memories()
+    assert text in all_mem
+    res = db.search_memories(emb, limit=1)
+    assert res[0] == text


### PR DESCRIPTION
## Summary
- add mem0_service FastAPI implementation with MCP
- store/search memories via Postgres or in-memory
- support OpenAI/OpenRouter/Ollama embeddings
- provide Dockerfile and docker-compose
- document configuration and usage
- add simple pytest round‑trip test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584913da488321a071b5169544308f